### PR TITLE
Aggiunta nuova voce AI004 'Generative AI / IA generativa'

### DIFF
--- a/docs/terms/AI004.md
+++ b/docs/terms/AI004.md
@@ -1,0 +1,19 @@
+# Generative AI / IA generativa (AI004)
+
+## Definizioni
+**IT**: Classe di sistemi di IA in grado di generare nuovi contenuti (testo, immagini, audio, codice, video) a partire da dati di addestramento o prompt, coerenti con pattern appresi ma non presenti come copie nei dati di origine.
+**EN**: A class of AI systems capable of generating novel content (text, images, audio, code, video) from training data or prompts, producing outputs consistent with learned patterns but not mere copies of the originals.
+
+## Fonti
+- NIST AI Risk Management Framework
+- ISO/IEC 22989:2022
+
+## Relazioni semantiche
+- **Più ampio (broader)**: [AI001](./AI001.md)
+- **Più specifico (narrower)**: —
+- **Correlati (related)**: —
+
+## Varianti
+AI generativa, Generative Artificial Intelligence
+
+[↩ Torna all’indice](./index.md)

--- a/docs/terms/index.md
+++ b/docs/terms/index.md
@@ -5,3 +5,4 @@
 | [AI001](./AI001.md) | Artificial Intelligence | Intelligenza artificiale |
 | [AI002](./AI002.md) | AI Act | Regolamento europeo sull’IA |
 | [AI003](./AI003.md) | Agentic AI | IA agentica |
+| [AI004](./AI004.md) | Generative AI | IA generativa |

--- a/tesauro.json
+++ b/tesauro.json
@@ -9,7 +9,7 @@
         "it": "Un sistema che ..."
       },
       "sources": [ "OECD Recommendation on AI (2019)", "ISO/IEC 22989:2022" ],
-      "relations": { "broader": [], "narrower": ["AI002"], "related": [] },
+      "relations": { "broader": [], "narrower": ["AI002", "AI004"], "related": [] },
       "variants": ["AI", "IA"]
     },
     {
@@ -39,6 +39,22 @@
       ],
       "relations": { "broader": ["AI001"], "narrower": [], "related": [] },
       "variants": ["Agentic Artificial Intelligence", "IA autonoma"]
+    },
+    {
+      "id": "AI004",
+      "english": "Generative AI",
+      "italian": "IA generativa",
+      "definition": {
+        "en": "A class of AI systems capable of generating novel content (text, images, audio, code, video) from training data or prompts, producing outputs consistent with learned patterns but not mere copies of the originals.",
+        "it": "Classe di sistemi di IA in grado di generare nuovi contenuti (testo, immagini, audio, codice, video) a partire da dati di addestramento o prompt, coerenti con pattern appresi ma non presenti come copie nei dati di origine."
+      },
+      "sources": [
+        "NIST AI Risk Management Framework",
+        "ISO/IEC 22989:2022"
+      ],
+      "relations": { "broader": ["AI001"], "narrower": [], "related": []
+      },
+      "variants": ["AI generativa", "Generative Artificial Intelligence"]
     }
   ]
 }


### PR DESCRIPTION
- Definizioni EN/IT
- Fonti tecniche/standard
- Relazione semantica: broader -> AI001

## Tipo di modifica
- [x] Nuova voce
- [ ] Modifica voce
- [ ] Rimozione voce
- [ ] Altro (specificare)

## Riferimenti
- Issue collegata: #3 
- Fonti normative/standard: 
  - NIST AI Risk Management Framework (AI RMF)
  - ISO/IEC 22989:2022 (terminologia AI)
  - Documentazione tecnica di modelli generativi diffusi (paper e rapporti istituzionali)

## Giustificazione editoriale (obbligatoria)
La voce è stata approvata perché ampiamente utilizzata in ambito tecnico e nelle discussioni di governance. L'inclusione migliora l'aderenza del Tesauro al lessico contemporaneo e chiarisce il rapporto gerarchico con "Artificial intelligence".

## Checklist
- [x] Aggiornato `tesauro.json`
- [x] Eseguito `python scripts/generate_docs.py`
- [x] Verificato che il sito si compila senza errori